### PR TITLE
feat: add mermaid-playground.nvim plugin

### DIFF
--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -5,13 +5,15 @@
   "friendly-snippets": { "branch": "main", "commit": "572f5660cf05f8cd8834e096d7b4c921ba18e175" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "lazydev.nvim": { "branch": "main", "commit": "5231c62aa83c2f8dc8e7ba957aa77098cda1257d" },
+  "live-server.nvim": { "branch": "main", "commit": "e8a34bc37fc565c678addbb352a59aa6c1842c2b" },
   "mason.nvim": { "branch": "main", "commit": "57e5a8addb8c71fb063ee4acda466c7cf6ad2800" },
-  "nvim-lspconfig": { "branch": "master", "commit": "d20d83b3f24f5884da73a9fc92fdc47e778b8d0d" },
-  "nvim-treesitter": { "branch": "main", "commit": "6e42d823ce0a5a76180c473c119c7677738a09d1" },
+  "mermaid-playground.nvim": { "branch": "main", "commit": "55ade6de60ad4a2fba683d33e940c166230f18e2" },
+  "nvim-lspconfig": { "branch": "master", "commit": "d696e36d5792daf828f8c8e8d4b9aa90c1a10c2a" },
+  "nvim-treesitter": { "branch": "main", "commit": "36fcb4a4238928f0b627e1ab84ade0acc1facc2c" },
   "nvim-web-devicons": { "branch": "master", "commit": "6788013bb9cb784e606ada44206b0e755e4323d7" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "render-markdown.nvim": { "branch": "main", "commit": "07d088bf8bdadd159eb807b90eaee86a4778383f" },
   "snacks.nvim": { "branch": "main", "commit": "fe7cfe9800a182274d0f868a74b7263b8c0c020b" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "6fea601bd2b694c6f2ae08a6c6fab14930c60e2c" },
-  "telescope.nvim": { "branch": "master", "commit": "e709d31454ee6e6157f0537f861f797bd44c0bad" }
+  "telescope.nvim": { "branch": "master", "commit": "4d0f5e0e7f69071e315515c385fab2a4eff07b3d" }
 }

--- a/nvim/.config/nvim/lua/plugins/mermaid-playground.lua
+++ b/nvim/.config/nvim/lua/plugins/mermaid-playground.lua
@@ -1,0 +1,24 @@
+return {
+  "selimacerbas/mermaid-playground.nvim",
+  dependencies = {
+    {
+      "barrett-ruth/live-server.nvim",
+      opts = {
+        args = { "--browser=google chrome" },
+      },
+    },
+  },
+  ft = { "markdown" },
+  config = function()
+    require("mermaid_playground").setup({
+      auto_refresh = true,
+      debounce_ms = 450,
+      notify_on_refresh = false,
+    })
+  end,
+  keys = {
+    { "<leader>mps", "<cmd>MermaidPreviewStart<cr>", desc = "Mermaid: Start preview" },
+    { "<leader>mpr", "<cmd>MermaidPreviewRefresh<cr>", desc = "Mermaid: Refresh" },
+    { "<leader>mpS", "<cmd>MermaidPreviewStop<cr>", desc = "Mermaid: Stop" },
+  },
+}


### PR DESCRIPTION
Add mermaid-playground plugin for previewing Mermaid diagrams in Neovim with live-server support.